### PR TITLE
[ADD] 장바구니 기능 구현

### DIFF
--- a/src/main/java/com/example/ddd_start/common/domain/Money.java
+++ b/src/main/java/com/example/ddd_start/common/domain/Money.java
@@ -19,8 +19,8 @@ public class Money {
     return new Money(this.amount + money.amount);
   }
 
-  public Money multiply(int quantity) {
-    return new Money(this.amount * quantity);
+  public Money multiply(float quantity) {
+    return new Money((int)(this.amount * quantity));
   }
 
   public Money subtract(Money money) {

--- a/src/main/java/com/example/ddd_start/coupon/Exception/CouponAlreadyUsedException.java
+++ b/src/main/java/com/example/ddd_start/coupon/Exception/CouponAlreadyUsedException.java
@@ -1,0 +1,8 @@
+package com.example.ddd_start.coupon.Exception;
+
+public class CouponAlreadyUsedException extends RuntimeException {
+
+  public CouponAlreadyUsedException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/example/ddd_start/coupon/application/CouponDefinitionService.java
+++ b/src/main/java/com/example/ddd_start/coupon/application/CouponDefinitionService.java
@@ -1,0 +1,94 @@
+package com.example.ddd_start.coupon.application;
+
+import com.example.ddd_start.common.domain.Money;
+import com.example.ddd_start.coupon.application.model.CouponDefinitionDto;
+import com.example.ddd_start.coupon.application.model.RegisterCouponDefinitionCommand;
+import com.example.ddd_start.coupon.application.model.UpdateCouponDefinitionCommand;
+import com.example.ddd_start.coupon.domain.CouponDefinition;
+import com.example.ddd_start.coupon.domain.CouponDefinitionRepository;
+import java.time.Instant;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CouponDefinitionService {
+
+  private final CouponDefinitionRepository couponDefinitionRepository;
+
+  @Transactional
+  public CouponDefinitionDto register(
+      RegisterCouponDefinitionCommand cmd) {
+
+    CouponDefinition couponDefinition = couponDefinitionRepository.save(
+        new CouponDefinition(
+            cmd.name(),
+            cmd.isRatio(),
+            cmd.ratio(),
+            new Money(cmd.fixedAmount())
+        )
+    );
+
+    couponDefinitionRepository.save(couponDefinition);
+
+    return new CouponDefinitionDto(
+        couponDefinition.getId(),
+        couponDefinition.getName(),
+        couponDefinition.getIsRatio(),
+        couponDefinition.getRatio(),
+        couponDefinition.getFixedAmount(),
+        couponDefinition.getCreatedAt(),
+        couponDefinition.getUpdatedAt(),
+        couponDefinition.getExpiredAt()
+    );
+  }
+
+  @Transactional
+  public CouponDefinitionDto update(UpdateCouponDefinitionCommand cmd) {
+    CouponDefinition couponDefinition = couponDefinitionRepository.findById(cmd.id())
+        .orElseThrow(RuntimeException::new);
+
+    couponDefinition.update(
+        cmd.name(),
+        cmd.isRatio(),
+        cmd.ratio(),
+        new Money(cmd.fixedAmount())
+    );
+
+    return new CouponDefinitionDto(
+        couponDefinition.getId(),
+        couponDefinition.getName(),
+        couponDefinition.getIsRatio(),
+        couponDefinition.getRatio(),
+        couponDefinition.getFixedAmount(),
+        couponDefinition.getCreatedAt(),
+        couponDefinition.getUpdatedAt(),
+        couponDefinition.getExpiredAt()
+    );
+  }
+
+  @Transactional(readOnly = true)
+  public List<CouponDefinitionDto> printAllValidated() {
+    return couponDefinitionRepository.findByExpiredAtAfter(Instant.now())
+        .stream()
+        .map(couponDefinition ->
+            new CouponDefinitionDto(
+                couponDefinition.getId(),
+                couponDefinition.getName(),
+                couponDefinition.getIsRatio(),
+                couponDefinition.getRatio(),
+                couponDefinition.getFixedAmount(),
+                couponDefinition.getCreatedAt(),
+                couponDefinition.getUpdatedAt(),
+                couponDefinition.getExpiredAt()
+            )
+        ).toList();
+  }
+
+  @Transactional
+  public void delete(Long id) {
+    couponDefinitionRepository.deleteById(id);
+  }
+}

--- a/src/main/java/com/example/ddd_start/coupon/application/UserCouponService.java
+++ b/src/main/java/com/example/ddd_start/coupon/application/UserCouponService.java
@@ -1,0 +1,69 @@
+package com.example.ddd_start.coupon.application;
+
+import com.example.ddd_start.coupon.application.model.UserCouponDto;
+import com.example.ddd_start.coupon.domain.CouponDefinition;
+import com.example.ddd_start.coupon.domain.CouponDefinitionRepository;
+import com.example.ddd_start.coupon.domain.UserCoupon;
+import com.example.ddd_start.coupon.domain.UserCouponRepository;
+import com.example.ddd_start.member.domain.Member;
+import com.example.ddd_start.member.domain.MemberRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserCouponService {
+
+  private final UserCouponRepository userCouponRepository;
+  private final CouponDefinitionRepository couponDefinitionRepository;
+  private final MemberRepository memberRepository;
+
+  @Transactional(readOnly = true)
+  public List<UserCouponDto> findByMemberId(Long memberId) {
+    return userCouponRepository.findAllByMemberIdAndIsUsedFalse(memberId)
+        .stream()
+        .map(userCoupon -> new UserCouponDto(
+                userCoupon.getId(),
+                userCoupon.getName(),
+                userCoupon.getIsUsed(),
+                userCoupon.getIsRatio(),
+                userCoupon.getRatio(),
+                userCoupon.getFixedAmount()
+            )
+        )
+        .toList();
+  }
+
+  @Transactional
+  public Long register(Long memberId, Long couponDefinitionId) {
+    CouponDefinition couponDefinition = couponDefinitionRepository.findById(couponDefinitionId)
+        .orElseThrow(() -> new RuntimeException("존재하지 않는 쿠폰입니다."));
+    Member member = memberRepository.findById(memberId)
+        .orElseThrow(() -> new RuntimeException("존재하지 않는 회원입니다."));
+
+    UserCoupon userCoupon = userCouponRepository.save(
+        new UserCoupon(member, couponDefinition));
+    return userCoupon.getId();
+  }
+
+  @Transactional
+  public void update(UserCouponDto userCouponDto) {
+    UserCoupon userCoupon = userCouponRepository.findById(userCouponDto.id())
+        .orElseThrow(() -> new RuntimeException("해당 쿠폰이 존재하지 않습니다."));
+
+    userCoupon.update(
+        userCouponDto.name(),
+        userCouponDto.isUsed(),
+        userCouponDto.isRatio(),
+        userCouponDto.ratio(),
+        userCouponDto.fixedAmount()
+    );
+    userCouponRepository.save(userCoupon);
+  }
+
+  public void delete(Long userCouponId) {
+    userCouponRepository.deleteById(userCouponId);
+  }
+}

--- a/src/main/java/com/example/ddd_start/coupon/application/model/CouponDefinitionDto.java
+++ b/src/main/java/com/example/ddd_start/coupon/application/model/CouponDefinitionDto.java
@@ -1,0 +1,17 @@
+package com.example.ddd_start.coupon.application.model;
+
+import com.example.ddd_start.common.domain.Money;
+import java.time.Instant;
+
+public record CouponDefinitionDto(
+    Long id,
+    String name,
+    Boolean isRatio,
+    Float ratio,
+    Money fixedAmount,
+    Instant createdAt,
+    Instant updatedAt,
+    Instant expiredAt
+) {
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/application/model/CouponDto.java
+++ b/src/main/java/com/example/ddd_start/coupon/application/model/CouponDto.java
@@ -1,0 +1,4 @@
+package com.example.ddd_start.coupon.application.model;
+
+public record CouponDto(Long id) {
+}

--- a/src/main/java/com/example/ddd_start/coupon/application/model/RegisterCouponDefinitionCommand.java
+++ b/src/main/java/com/example/ddd_start/coupon/application/model/RegisterCouponDefinitionCommand.java
@@ -1,0 +1,6 @@
+package com.example.ddd_start.coupon.application.model;
+
+public record RegisterCouponDefinitionCommand(
+    String name, Boolean isRatio, Float ratio, Integer fixedAmount) {
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/application/model/UpdateCouponDefinitionCommand.java
+++ b/src/main/java/com/example/ddd_start/coupon/application/model/UpdateCouponDefinitionCommand.java
@@ -1,0 +1,6 @@
+package com.example.ddd_start.coupon.application.model;
+
+public record UpdateCouponDefinitionCommand(
+    Long id, String name, Boolean isRatio, Float ratio, Integer fixedAmount) {
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/application/model/UserCouponDto.java
+++ b/src/main/java/com/example/ddd_start/coupon/application/model/UserCouponDto.java
@@ -1,4 +1,4 @@
 package com.example.ddd_start.coupon.application.model;
 
-public record CouponDto(Long id) {
+public record UserCouponDto(Long id) {
 }

--- a/src/main/java/com/example/ddd_start/coupon/application/model/UserCouponDto.java
+++ b/src/main/java/com/example/ddd_start/coupon/application/model/UserCouponDto.java
@@ -1,4 +1,8 @@
 package com.example.ddd_start.coupon.application.model;
 
-public record UserCouponDto(Long id) {
+import com.example.ddd_start.common.domain.Money;
+
+public record UserCouponDto(Long id, String name, Boolean isUsed, Boolean isRatio, Float ratio,
+                            Money fixedAmount) {
+
 }

--- a/src/main/java/com/example/ddd_start/coupon/domain/Coupon.java
+++ b/src/main/java/com/example/ddd_start/coupon/domain/Coupon.java
@@ -1,13 +1,18 @@
 package com.example.ddd_start.coupon.domain;
 
 import com.example.ddd_start.common.domain.Money;
+import com.example.ddd_start.coupon.Exception.CouponAlreadyUsedException;
+import com.example.ddd_start.member.domain.Member;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.NoArgsConstructor;
 
 @Entity
+@NoArgsConstructor
 public class Coupon {
 
   @Id
@@ -17,6 +22,33 @@ public class Coupon {
   private Boolean isUsed;
   private Boolean isRatio;
   private Float ratio;
+  @ManyToOne
+  Member member;
   @Embedded
   private Money fixedAmount;
+
+  public Coupon(String name, Boolean isUsed, Boolean isRatio, Float ratio, Member member,
+      Money fixedAmount) {
+    this.name = name;
+    this.isUsed = isUsed;
+    this.isRatio = isRatio;
+    this.ratio = ratio;
+    this.member = member;
+    this.fixedAmount = fixedAmount;
+  }
+
+  public Money redeemCoupon(Money money) {
+    if (this.isUsed) {
+      throw new CouponAlreadyUsedException("Coupon is used");
+    }
+
+    if (isRatio) {
+      return money.multiply(ratio);
+    }
+    return money.subtract(fixedAmount);
+  }
+
+  public void useCoupon(){
+    isUsed = true;
+  }
 }

--- a/src/main/java/com/example/ddd_start/coupon/domain/CouponDefinition.java
+++ b/src/main/java/com/example/ddd_start/coupon/domain/CouponDefinition.java
@@ -1,0 +1,56 @@
+package com.example.ddd_start.coupon.domain;
+
+import com.example.ddd_start.common.domain.Money;
+import java.time.Instant;
+import java.time.ZoneId;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class CouponDefinition {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  private String name;
+  private Boolean isRatio;
+  private Float ratio;
+  @Embedded
+  private Money fixedAmount;
+  private Instant createdAt;
+  private Instant updatedAt;
+  private Instant expiredAt;
+
+  public CouponDefinition(String name, Boolean isRatio, Float ratio, Money fixedAmount) {
+    this.name = name;
+    this.isRatio = isRatio;
+    this.ratio = ratio;
+    this.fixedAmount = fixedAmount;
+    this.createdAt = Instant.now();
+    this.updatedAt = Instant.now();
+    this.expiredAt = Instant.now()
+        .atZone(ZoneId.systemDefault())
+        .plusMonths(3)
+        .toInstant();
+  }
+
+  public void update(String name, Boolean isRatio, Float ratio, Money fixedAmount) {
+    this.name = name;
+    this.isRatio = isRatio;
+    this.ratio = ratio;
+    this.fixedAmount = fixedAmount;
+    this.updatedAt = Instant.now();
+    this.expiredAt = Instant.now()
+        .atZone(ZoneId.systemDefault())
+        .plusMonths(3)
+        .toInstant();
+  }
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/domain/CouponDefinitionRepository.java
+++ b/src/main/java/com/example/ddd_start/coupon/domain/CouponDefinitionRepository.java
@@ -1,0 +1,10 @@
+package com.example.ddd_start.coupon.domain;
+
+import java.time.Instant;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponDefinitionRepository extends JpaRepository<CouponDefinition, Long> {
+
+  List<CouponDefinition> findByExpiredAtAfter(Instant now);
+}

--- a/src/main/java/com/example/ddd_start/coupon/domain/CouponRepository.java
+++ b/src/main/java/com/example/ddd_start/coupon/domain/CouponRepository.java
@@ -1,0 +1,9 @@
+package com.example.ddd_start.coupon.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CouponRepository extends JpaRepository<Coupon, Long> {
+
+  public void deleteAllByMemberId(Long memberId);
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/domain/UserCoupon.java
+++ b/src/main/java/com/example/ddd_start/coupon/domain/UserCoupon.java
@@ -3,16 +3,20 @@ package com.example.ddd_start.coupon.domain;
 import com.example.ddd_start.common.domain.Money;
 import com.example.ddd_start.coupon.Exception.CouponAlreadyUsedException;
 import com.example.ddd_start.member.domain.Member;
+import java.time.Instant;
+import java.time.ZoneId;
 import javax.persistence.Embedded;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.ManyToOne;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
+@Getter
 public class UserCoupon {
 
   @Id
@@ -26,6 +30,10 @@ public class UserCoupon {
   Member member;
   @Embedded
   private Money fixedAmount;
+  private Instant createdAt;
+  private Instant updatedAt;
+  private Instant usedAt;
+  private Instant expiredAt;
 
   public UserCoupon(String name, Boolean isUsed, Boolean isRatio, Float ratio, Member member,
       Money fixedAmount) {
@@ -35,6 +43,27 @@ public class UserCoupon {
     this.ratio = ratio;
     this.member = member;
     this.fixedAmount = fixedAmount;
+    this.createdAt = Instant.now();
+    this.updatedAt = Instant.now();
+    this.expiredAt = Instant.now()
+        .atZone(ZoneId.systemDefault())
+        .plusMonths(3)
+        .toInstant();
+  }
+
+  public UserCoupon(Member member, CouponDefinition couponDefinition) {
+    this.name = couponDefinition.getName();
+    this.isUsed = false;
+    this.isRatio = couponDefinition.getIsRatio();
+    this.ratio = couponDefinition.getRatio();
+    this.fixedAmount = couponDefinition.getFixedAmount();
+    this.member = member;
+    this.createdAt = Instant.now();
+    this.updatedAt = Instant.now();
+    this.expiredAt = Instant.now()
+        .atZone(ZoneId.systemDefault())
+        .plusMonths(3)
+        .toInstant();
   }
 
   public Money redeemCoupon(Money money) {
@@ -48,7 +77,17 @@ public class UserCoupon {
     return money.subtract(fixedAmount);
   }
 
-  public void useCoupon(){
+  public void useCoupon() {
+    usedAt = Instant.now();
     isUsed = true;
+  }
+
+  public void update(String name, Boolean used, Boolean isRatio, Float ratio, Money fixedAmount) {
+    this.name = name;
+    this.isUsed = used;
+    this.isRatio = isRatio;
+    this.ratio = ratio;
+    this.fixedAmount = fixedAmount;
+    this.updatedAt = Instant.now();
   }
 }

--- a/src/main/java/com/example/ddd_start/coupon/domain/UserCoupon.java
+++ b/src/main/java/com/example/ddd_start/coupon/domain/UserCoupon.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor
-public class Coupon {
+public class UserCoupon {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -27,7 +27,7 @@ public class Coupon {
   @Embedded
   private Money fixedAmount;
 
-  public Coupon(String name, Boolean isUsed, Boolean isRatio, Float ratio, Member member,
+  public UserCoupon(String name, Boolean isUsed, Boolean isRatio, Float ratio, Member member,
       Money fixedAmount) {
     this.name = name;
     this.isUsed = isUsed;

--- a/src/main/java/com/example/ddd_start/coupon/domain/UserCouponRepository.java
+++ b/src/main/java/com/example/ddd_start/coupon/domain/UserCouponRepository.java
@@ -1,9 +1,11 @@
 package com.example.ddd_start.coupon.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
 
   public void deleteAllByMemberId(Long memberId);
+  public List<UserCoupon> findAllByMemberIdAndIsUsedFalse(Long memberId);
 
 }

--- a/src/main/java/com/example/ddd_start/coupon/domain/UserCouponRepository.java
+++ b/src/main/java/com/example/ddd_start/coupon/domain/UserCouponRepository.java
@@ -2,7 +2,7 @@ package com.example.ddd_start.coupon.domain;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface CouponRepository extends JpaRepository<Coupon, Long> {
+public interface UserCouponRepository extends JpaRepository<UserCoupon, Long> {
 
   public void deleteAllByMemberId(Long memberId);
 

--- a/src/main/java/com/example/ddd_start/coupon/presentation/CouponDefinitionController.java
+++ b/src/main/java/com/example/ddd_start/coupon/presentation/CouponDefinitionController.java
@@ -5,7 +5,9 @@ import com.example.ddd_start.coupon.application.model.CouponDefinitionDto;
 import com.example.ddd_start.coupon.application.model.RegisterCouponDefinitionCommand;
 import com.example.ddd_start.coupon.application.model.UpdateCouponDefinitionCommand;
 import com.example.ddd_start.coupon.presentation.model.RegisterCouponDefinitionRequest;
+import com.example.ddd_start.coupon.presentation.model.RegisterCouponDefinitionResponse;
 import com.example.ddd_start.coupon.presentation.model.UpdateCouponDefinitionRequest;
+import com.example.ddd_start.coupon.presentation.model.UpdateCouponDefinitionResponse;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -39,7 +41,8 @@ public class CouponDefinitionController {
             req.fixedAmount()
         ));
 
-    return ResponseEntity.ok(register);
+    return ResponseEntity
+        .ok(new RegisterCouponDefinitionResponse(register, "쿠폰이 정상적으로 정의되었습니다."));
   }
 
   @PutMapping("/coupon-definition")
@@ -54,7 +57,8 @@ public class CouponDefinitionController {
         )
     );
 
-    return ResponseEntity.ok(update);
+    return ResponseEntity
+        .ok(new UpdateCouponDefinitionResponse(update, "쿠폰 정의가 정상적으로 변경되었습니다."));
   }
 
   @DeleteMapping("coupon-definition")

--- a/src/main/java/com/example/ddd_start/coupon/presentation/CouponDefinitionController.java
+++ b/src/main/java/com/example/ddd_start/coupon/presentation/CouponDefinitionController.java
@@ -1,0 +1,68 @@
+package com.example.ddd_start.coupon.presentation;
+
+import com.example.ddd_start.coupon.application.CouponDefinitionService;
+import com.example.ddd_start.coupon.application.model.CouponDefinitionDto;
+import com.example.ddd_start.coupon.application.model.RegisterCouponDefinitionCommand;
+import com.example.ddd_start.coupon.application.model.UpdateCouponDefinitionCommand;
+import com.example.ddd_start.coupon.presentation.model.RegisterCouponDefinitionRequest;
+import com.example.ddd_start.coupon.presentation.model.UpdateCouponDefinitionRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class CouponDefinitionController {
+
+  private final CouponDefinitionService couponDefinitionService;
+
+  @GetMapping("/coupon-definition")
+  public ResponseEntity printAllValidated() {
+    List<CouponDefinitionDto> dtos = couponDefinitionService.printAllValidated();
+    return ResponseEntity.ok(dtos);
+  }
+
+  @PostMapping("/coupon-definition")
+  public ResponseEntity register(@RequestBody RegisterCouponDefinitionRequest req) {
+    CouponDefinitionDto register = couponDefinitionService.register(
+        new RegisterCouponDefinitionCommand(
+            req.name(),
+            req.isRatio(),
+            req.ratio(),
+            req.fixedAmount()
+        ));
+
+    return ResponseEntity.ok(register);
+  }
+
+  @PutMapping("/coupon-definition")
+  public ResponseEntity update(@RequestBody UpdateCouponDefinitionRequest req) {
+    CouponDefinitionDto update = couponDefinitionService.update(
+        new UpdateCouponDefinitionCommand(
+            req.id(),
+            req.name(),
+            req.isRatio(),
+            req.ratio(),
+            req.fixedAmount()
+        )
+    );
+
+    return ResponseEntity.ok(update);
+  }
+
+  @DeleteMapping("coupon-definition")
+  public ResponseEntity delete(@RequestParam("id") Long id) {
+    couponDefinitionService.delete(id);
+
+    return ResponseEntity.ok().build();
+  }
+
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/presentation/UserCouponController.java
+++ b/src/main/java/com/example/ddd_start/coupon/presentation/UserCouponController.java
@@ -1,0 +1,68 @@
+package com.example.ddd_start.coupon.presentation;
+
+import com.example.ddd_start.coupon.application.UserCouponService;
+import com.example.ddd_start.coupon.application.model.UserCouponDto;
+import com.example.ddd_start.coupon.presentation.model.RegisterUserCouponRequest;
+import com.example.ddd_start.coupon.presentation.model.RegisterUserCouponResponse;
+import com.example.ddd_start.coupon.presentation.model.UpdateUserCouponRequest;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class UserCouponController {
+
+  private final UserCouponService userCouponService;
+
+  @GetMapping("/user-coupons/{memberId}")
+  public ResponseEntity printAll(@PathVariable("memberId") Long memberId) {
+    List<UserCouponDto> dtos = userCouponService.findByMemberId(memberId);
+
+    return ResponseEntity.ok(dtos);
+  }
+
+  @PostMapping("/user-coupons")
+  public ResponseEntity register(@RequestBody RegisterUserCouponRequest req) {
+    Long userCouponId = userCouponService.register(
+        req.memberId(),
+        req.couponDefinitionId()
+    );
+
+    return ResponseEntity
+        .ok(new RegisterUserCouponResponse(userCouponId, "쿠폰이 정상적으로 등록되었습니다."));
+  }
+
+  @PutMapping("/user-coupons")
+  public ResponseEntity update(@RequestBody UpdateUserCouponRequest req) {
+    userCouponService.update(
+        new UserCouponDto(
+            req.id(),
+            req.name(),
+            req.isUsed(),
+            req.isRatio(),
+            req.ratio(),
+            req.fixedAmount()
+        )
+    );
+
+    return ResponseEntity
+        .ok("쿠폰이 정상적으로 변경되었습니다.");
+  }
+
+  @DeleteMapping("/user-coupons")
+  public ResponseEntity delete(@RequestParam Long userCouponId) {
+    userCouponService.delete(userCouponId);
+
+    return ResponseEntity
+        .ok("쿠폰이 정상적으로 삭제되었습니다.");
+  }
+}

--- a/src/main/java/com/example/ddd_start/coupon/presentation/model/RegisterCouponDefinitionRequest.java
+++ b/src/main/java/com/example/ddd_start/coupon/presentation/model/RegisterCouponDefinitionRequest.java
@@ -1,0 +1,9 @@
+package com.example.ddd_start.coupon.presentation.model;
+
+public record RegisterCouponDefinitionRequest(
+    String name,
+    Boolean isRatio,
+    Float ratio,
+    Integer fixedAmount) {
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/presentation/model/RegisterCouponDefinitionResponse.java
+++ b/src/main/java/com/example/ddd_start/coupon/presentation/model/RegisterCouponDefinitionResponse.java
@@ -1,0 +1,7 @@
+package com.example.ddd_start.coupon.presentation.model;
+
+import com.example.ddd_start.coupon.application.model.CouponDefinitionDto;
+
+public record RegisterCouponDefinitionResponse(CouponDefinitionDto register, String message) {
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/presentation/model/RegisterUserCouponRequest.java
+++ b/src/main/java/com/example/ddd_start/coupon/presentation/model/RegisterUserCouponRequest.java
@@ -1,0 +1,5 @@
+package com.example.ddd_start.coupon.presentation.model;
+
+public record RegisterUserCouponRequest(Long memberId, Long couponDefinitionId) {
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/presentation/model/RegisterUserCouponResponse.java
+++ b/src/main/java/com/example/ddd_start/coupon/presentation/model/RegisterUserCouponResponse.java
@@ -1,0 +1,5 @@
+package com.example.ddd_start.coupon.presentation.model;
+
+public record RegisterUserCouponResponse(Long couponId, String message) {
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/presentation/model/UpdateCouponDefinitionRequest.java
+++ b/src/main/java/com/example/ddd_start/coupon/presentation/model/UpdateCouponDefinitionRequest.java
@@ -1,0 +1,11 @@
+package com.example.ddd_start.coupon.presentation.model;
+
+public record UpdateCouponDefinitionRequest(
+    Long id,
+    String name,
+    Boolean isRatio,
+    Float ratio,
+    Integer fixedAmount
+) {
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/presentation/model/UpdateCouponDefinitionResponse.java
+++ b/src/main/java/com/example/ddd_start/coupon/presentation/model/UpdateCouponDefinitionResponse.java
@@ -1,0 +1,7 @@
+package com.example.ddd_start.coupon.presentation.model;
+
+import com.example.ddd_start.coupon.application.model.CouponDefinitionDto;
+
+public record UpdateCouponDefinitionResponse(CouponDefinitionDto update, String message) {
+
+}

--- a/src/main/java/com/example/ddd_start/coupon/presentation/model/UpdateUserCouponRequest.java
+++ b/src/main/java/com/example/ddd_start/coupon/presentation/model/UpdateUserCouponRequest.java
@@ -1,0 +1,10 @@
+package com.example.ddd_start.coupon.presentation.model;
+
+import com.example.ddd_start.common.domain.Money;
+
+public record UpdateUserCouponRequest(
+    Long id, String name, Boolean isUsed, Boolean isRatio, Float ratio,
+    Money fixedAmount
+) {
+
+}

--- a/src/main/java/com/example/ddd_start/member/applicaiton/DeleteMemberService.java
+++ b/src/main/java/com/example/ddd_start/member/applicaiton/DeleteMemberService.java
@@ -1,10 +1,9 @@
 package com.example.ddd_start.member.applicaiton;
 
-import com.example.ddd_start.coupon.domain.CouponRepository;
+import com.example.ddd_start.coupon.domain.UserCouponRepository;
 import com.example.ddd_start.member.domain.MemberRepository;
 import com.example.ddd_start.product.domain.LastlyRetrieveProductRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,14 +13,14 @@ public class DeleteMemberService {
 
   private final MemberRepository memberRepository;
   private final LastlyRetrieveProductRepository lastlyRetrieveProductRepository;
-  private final CouponRepository couponRepository;
+  private final UserCouponRepository userCouponRepository;
 
   @Transactional
   public void delete(Long id) {
     memberRepository.findById(id).ifPresent(member -> {
       memberRepository.delete(member);
       lastlyRetrieveProductRepository.deleteAllByMember(member);
-      couponRepository.deleteAllByMemberId(member.getId());
+      userCouponRepository.deleteAllByMemberId(member.getId());
     });
   }
 }

--- a/src/main/java/com/example/ddd_start/member/applicaiton/DeleteMemberService.java
+++ b/src/main/java/com/example/ddd_start/member/applicaiton/DeleteMemberService.java
@@ -2,6 +2,7 @@ package com.example.ddd_start.member.applicaiton;
 
 import com.example.ddd_start.coupon.domain.UserCouponRepository;
 import com.example.ddd_start.member.domain.MemberRepository;
+import com.example.ddd_start.order.domain.CartRepository;
 import com.example.ddd_start.product.domain.LastlyRetrieveProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,6 +15,7 @@ public class DeleteMemberService {
   private final MemberRepository memberRepository;
   private final LastlyRetrieveProductRepository lastlyRetrieveProductRepository;
   private final UserCouponRepository userCouponRepository;
+  private final CartRepository cartRepository;
 
   @Transactional
   public void delete(Long id) {
@@ -21,6 +23,7 @@ public class DeleteMemberService {
       memberRepository.delete(member);
       lastlyRetrieveProductRepository.deleteAllByMember(member);
       userCouponRepository.deleteAllByMemberId(member.getId());
+      cartRepository.deleteAllByMemberId(member.getId());
     });
   }
 }

--- a/src/main/java/com/example/ddd_start/member/applicaiton/DeleteMemberService.java
+++ b/src/main/java/com/example/ddd_start/member/applicaiton/DeleteMemberService.java
@@ -1,5 +1,6 @@
 package com.example.ddd_start.member.applicaiton;
 
+import com.example.ddd_start.coupon.domain.CouponRepository;
 import com.example.ddd_start.member.domain.MemberRepository;
 import com.example.ddd_start.product.domain.LastlyRetrieveProductRepository;
 import lombok.RequiredArgsConstructor;
@@ -13,12 +14,14 @@ public class DeleteMemberService {
 
   private final MemberRepository memberRepository;
   private final LastlyRetrieveProductRepository lastlyRetrieveProductRepository;
+  private final CouponRepository couponRepository;
 
   @Transactional
   public void delete(Long id) {
     memberRepository.findById(id).ifPresent(member -> {
       memberRepository.delete(member);
       lastlyRetrieveProductRepository.deleteAllByMember(member);
+      couponRepository.deleteAllByMemberId(member.getId());
     });
   }
 }

--- a/src/main/java/com/example/ddd_start/order/application/model/CartDto.java
+++ b/src/main/java/com/example/ddd_start/order/application/model/CartDto.java
@@ -1,0 +1,11 @@
+package com.example.ddd_start.order.application.model;
+
+import com.example.ddd_start.common.domain.Money;
+
+public record CartDto(Long id,
+                      String productName,
+                      Money price,
+                      String imageUrl,
+                      Integer quantity) {
+
+}

--- a/src/main/java/com/example/ddd_start/order/application/model/CreateCartCommand.java
+++ b/src/main/java/com/example/ddd_start/order/application/model/CreateCartCommand.java
@@ -1,0 +1,5 @@
+package com.example.ddd_start.order.application.model;
+
+public record CreateCartCommand(Long memberId, Long productId, Integer quantity) {
+
+}

--- a/src/main/java/com/example/ddd_start/order/application/model/PlaceOrderCommand.java
+++ b/src/main/java/com/example/ddd_start/order/application/model/PlaceOrderCommand.java
@@ -1,19 +1,12 @@
 package com.example.ddd_start.order.application.model;
 
-import com.example.ddd_start.coupon.domain.Coupon;
-import com.example.ddd_start.order.domain.OrderLine;
+import com.example.ddd_start.coupon.application.model.CouponDto;
+import com.example.ddd_start.order.domain.dto.OrderLineDto;
 import com.example.ddd_start.order.domain.value.Orderer;
 import com.example.ddd_start.order.domain.value.ShippingInfo;
 import java.util.List;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
-public class PlaceOrderCommand {
+public record PlaceOrderCommand(List<OrderLineDto> orderLines, ShippingInfo shippingInfo,
+                                Orderer orderer, List<CouponDto> coupons) {
 
-  private final List<OrderLine> orderLines;
-  private final ShippingInfo shippingInfo;
-  private final Orderer orderer;
-  private final List<Coupon> coupons;
 }

--- a/src/main/java/com/example/ddd_start/order/application/model/PlaceOrderCommand.java
+++ b/src/main/java/com/example/ddd_start/order/application/model/PlaceOrderCommand.java
@@ -1,12 +1,12 @@
 package com.example.ddd_start.order.application.model;
 
-import com.example.ddd_start.coupon.application.model.CouponDto;
+import com.example.ddd_start.coupon.application.model.UserCouponDto;
 import com.example.ddd_start.order.domain.dto.OrderLineDto;
 import com.example.ddd_start.order.domain.value.Orderer;
 import com.example.ddd_start.order.domain.value.ShippingInfo;
 import java.util.List;
 
 public record PlaceOrderCommand(List<OrderLineDto> orderLines, ShippingInfo shippingInfo,
-                                Orderer orderer, List<CouponDto> coupons) {
+                                Orderer orderer, List<UserCouponDto> coupons) {
 
 }

--- a/src/main/java/com/example/ddd_start/order/application/service/CartService.java
+++ b/src/main/java/com/example/ddd_start/order/application/service/CartService.java
@@ -1,0 +1,79 @@
+package com.example.ddd_start.order.application.service;
+
+import com.example.ddd_start.member.domain.Member;
+import com.example.ddd_start.member.domain.MemberRepository;
+import com.example.ddd_start.order.application.model.CartDto;
+import com.example.ddd_start.order.application.model.CreateCartCommand;
+import com.example.ddd_start.order.domain.Cart;
+import com.example.ddd_start.order.domain.CartRepository;
+import com.example.ddd_start.product.domain.Product;
+import com.example.ddd_start.product.domain.ProductRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CartService {
+
+  private final CartRepository cartRepository;
+  private final MemberRepository memberRepository;
+  private final ProductRepository productRepository;
+
+  @Transactional
+  public Long save(CreateCartCommand cmd) {
+    Member member = memberRepository.findById(cmd.memberId())
+        .orElseThrow(() -> new IllegalArgumentException("Member not found"));
+    Product product = productRepository.findById(cmd.productId())
+        .orElseThrow(() -> new IllegalArgumentException("Product not found"));
+
+    Cart cart = new Cart(member,
+        product,
+        cmd.quantity());
+
+    Cart save = cartRepository.save(cart);
+    return save.getId();
+  }
+
+  @Transactional(readOnly = true)
+  public List<CartDto> printAllCarts(Long memberId) {
+    return cartRepository.findByMemberId(memberId).stream()
+        .map(cart -> new CartDto(
+            cart.getId(),
+            cart.getProduct().getTitle(),
+            cart.getProduct().getPrice(),
+            cart.getProduct().getImages().get(0),
+            cart.getQuantity()
+        ))
+        .toList();
+  }
+
+  @Transactional
+  public CartDto update(UpdateCartCommand cmd) {
+    Cart cart = cartRepository.findById(cmd.cartId())
+        .orElseThrow(() -> new IllegalArgumentException("Cart not found"));
+
+    cart.update(cmd.quantity());
+
+    cartRepository.save(cart);
+    return new CartDto(
+        cart.getId(),
+        cart.getProduct().getTitle(),
+        cart.getProduct().getPrice(),
+        cart.getProduct().getImages().get(0),
+        cart.getQuantity()
+    );
+  }
+
+  @Transactional
+  public void delete(Long cartId) {
+    cartRepository.deleteById(cartId);
+  }
+
+  @Transactional
+  public void deleteAll(Long memberId) {
+    cartRepository.deleteAllByMemberId(memberId);
+  }
+
+}

--- a/src/main/java/com/example/ddd_start/order/application/service/OrderService.java
+++ b/src/main/java/com/example/ddd_start/order/application/service/OrderService.java
@@ -4,8 +4,7 @@ import com.example.ddd_start.common.domain.error.ValidationError;
 import com.example.ddd_start.common.domain.exception.NoOrderException;
 import com.example.ddd_start.common.domain.exception.ValidationErrorException;
 import com.example.ddd_start.common.domain.exception.VersionConflictException;
-import com.example.ddd_start.coupon.application.model.CouponDto;
-import com.example.ddd_start.coupon.domain.Coupon;
+import com.example.ddd_start.coupon.application.model.UserCouponDto;
 import com.example.ddd_start.member.domain.Member;
 import com.example.ddd_start.member.domain.MemberRepository;
 import com.example.ddd_start.order.application.model.ChangeOrderShippingInfoCommand;
@@ -135,7 +134,7 @@ public class OrderService {
     return order.getId();
   }
 
-  private Order calculatePaymentInfo(Order order, List<CouponDto> coupons) {
+  private Order calculatePaymentInfo(Order order, List<UserCouponDto> coupons) {
     Member member = memberRepository.findById(order.getOrderer().getMemberId())
         .orElseThrow(NoSuchElementException::new);
 

--- a/src/main/java/com/example/ddd_start/order/application/service/UpdateCartCommand.java
+++ b/src/main/java/com/example/ddd_start/order/application/service/UpdateCartCommand.java
@@ -1,0 +1,5 @@
+package com.example.ddd_start.order.application.service;
+
+public record UpdateCartCommand(Long cartId, Integer quantity) {
+
+}

--- a/src/main/java/com/example/ddd_start/order/domain/Cart.java
+++ b/src/main/java/com/example/ddd_start/order/domain/Cart.java
@@ -1,0 +1,35 @@
+package com.example.ddd_start.order.domain;
+
+import com.example.ddd_start.member.domain.Member;
+import com.example.ddd_start.product.domain.Product;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Entity
+@NoArgsConstructor
+public class Cart {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @ManyToOne
+  private Member member;
+  @ManyToOne
+  private Product product;
+  private Integer quantity;
+
+  public Cart(Member member, Product product, Integer quantity) {
+    this.member = member;
+    this.product = product;
+    this.quantity = quantity;
+  }
+
+  public void update(Integer quantity) {
+    this.quantity = quantity;
+  }
+}

--- a/src/main/java/com/example/ddd_start/order/domain/CartRepository.java
+++ b/src/main/java/com/example/ddd_start/order/domain/CartRepository.java
@@ -1,0 +1,9 @@
+package com.example.ddd_start.order.domain;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CartRepository extends JpaRepository<Cart, Long> {
+  public List<Cart> findByMemberId(Long memberId);
+  public void deleteAllByMemberId(Long memberId);
+}

--- a/src/main/java/com/example/ddd_start/order/domain/Order.java
+++ b/src/main/java/com/example/ddd_start/order/domain/Order.java
@@ -5,10 +5,11 @@ import static com.example.ddd_start.order.domain.value.OrderState.PAYMENT_WAITIN
 import static com.example.ddd_start.order.domain.value.OrderState.PREPARING;
 import static com.example.ddd_start.order.domain.value.OrderState.SHIPPED;
 
-import com.example.ddd_start.common.application.event.Events;
 import com.example.ddd_start.common.domain.Money;
+import com.example.ddd_start.coupon.application.model.CouponDto;
 import com.example.ddd_start.coupon.domain.Coupon;
 import com.example.ddd_start.member.domain.MemberGrade;
+import com.example.ddd_start.order.domain.dto.OrderLineDto;
 import com.example.ddd_start.order.domain.event.OrderCanceledEvent;
 import com.example.ddd_start.order.domain.event.OrderEvent;
 import com.example.ddd_start.order.domain.event.ShippingInfoChangedEvent;
@@ -38,7 +39,6 @@ import javax.persistence.Transient;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.Version;
-import org.springframework.data.domain.DomainEvents;
 
 @Getter
 @Entity(name = "orders")
@@ -85,6 +85,7 @@ public class Order {
     setOrderLines(orderLines);
     setShippingInfo(shippingInfo);
     setOrderer(orderer);
+    createdAt = Instant.now();
   }
 
   private void setOrderer(Orderer orderer) {
@@ -119,8 +120,8 @@ public class Order {
 
   private Money calculateTotalAmounts() {
     return new Money(this.orderLines.stream()
-            .mapToInt(o -> o.getAmount().getAmount())
-            .sum());
+        .mapToInt(o -> o.getAmount().getAmount())
+        .sum());
   }
 
   public void changeShippingInfo(ShippingInfo shippingInfo) {
@@ -165,7 +166,7 @@ public class Order {
   }
 
   public void calculateAmounts(
-      DiscountCalculationService disCalSvc, MemberGrade grade, List<Coupon> coupons
+      DiscountCalculationService disCalSvc, MemberGrade grade, List<CouponDto> coupons
   ) {
     Money totalAmounts = getTotalAmounts();
     Money discountAmounts = disCalSvc.calculateDiscountAmounts(orderLines, coupons, grade);

--- a/src/main/java/com/example/ddd_start/order/domain/Order.java
+++ b/src/main/java/com/example/ddd_start/order/domain/Order.java
@@ -6,10 +6,8 @@ import static com.example.ddd_start.order.domain.value.OrderState.PREPARING;
 import static com.example.ddd_start.order.domain.value.OrderState.SHIPPED;
 
 import com.example.ddd_start.common.domain.Money;
-import com.example.ddd_start.coupon.application.model.CouponDto;
-import com.example.ddd_start.coupon.domain.Coupon;
+import com.example.ddd_start.coupon.application.model.UserCouponDto;
 import com.example.ddd_start.member.domain.MemberGrade;
-import com.example.ddd_start.order.domain.dto.OrderLineDto;
 import com.example.ddd_start.order.domain.event.OrderCanceledEvent;
 import com.example.ddd_start.order.domain.event.OrderEvent;
 import com.example.ddd_start.order.domain.event.ShippingInfoChangedEvent;
@@ -166,7 +164,7 @@ public class Order {
   }
 
   public void calculateAmounts(
-      DiscountCalculationService disCalSvc, MemberGrade grade, List<CouponDto> coupons
+      DiscountCalculationService disCalSvc, MemberGrade grade, List<UserCouponDto> coupons
   ) {
     Money totalAmounts = getTotalAmounts();
     Money discountAmounts = disCalSvc.calculateDiscountAmounts(orderLines, coupons, grade);

--- a/src/main/java/com/example/ddd_start/order/domain/OrderLine.java
+++ b/src/main/java/com/example/ddd_start/order/domain/OrderLine.java
@@ -35,16 +35,25 @@ public class OrderLine {
   private Money price;
   private Integer quantity;
 
-  public OrderLine(Product product, Order order, Integer quantity) {
+  public OrderLine(Product product, Order order, Integer price, Integer quantity) {
     changeProduct(product);
     changeOrder(order);
     this.price = product.getPrice();
-    this.amount = calculateAmount();
     this.quantity = quantity;
+    this.price = new Money(price);
+    this.amount = calculateAmount();
+  }
+
+  public OrderLine(Product product, Integer price, Integer quantity) {
+    changeProduct(product);
+    this.price = product.getPrice();
+    this.quantity = quantity;
+    this.price = new Money(price);
+    this.amount = calculateAmount();
   }
 
   private Money calculateAmount() {
-    return this.amount.multiply(quantity);
+    return this.price.multiply(quantity);
   }
 
   private void changeOrder(Order order) {

--- a/src/main/java/com/example/ddd_start/order/domain/dto/OrderLineDto.java
+++ b/src/main/java/com/example/ddd_start/order/domain/dto/OrderLineDto.java
@@ -1,0 +1,4 @@
+package com.example.ddd_start.order.domain.dto;
+
+public record OrderLineDto(Long productId, Long amount, Integer price, Integer quantity) {
+}

--- a/src/main/java/com/example/ddd_start/order/domain/service/DiscountCalculationService.java
+++ b/src/main/java/com/example/ddd_start/order/domain/service/DiscountCalculationService.java
@@ -1,9 +1,9 @@
 package com.example.ddd_start.order.domain.service;
 
 import com.example.ddd_start.common.domain.Money;
-import com.example.ddd_start.coupon.application.model.CouponDto;
-import com.example.ddd_start.coupon.domain.Coupon;
-import com.example.ddd_start.coupon.domain.CouponRepository;
+import com.example.ddd_start.coupon.application.model.UserCouponDto;
+import com.example.ddd_start.coupon.domain.UserCoupon;
+import com.example.ddd_start.coupon.domain.UserCouponRepository;
 import com.example.ddd_start.member.domain.MemberGrade;
 import com.example.ddd_start.order.domain.OrderLine;
 import java.util.List;
@@ -14,38 +14,38 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class DiscountCalculationService {
-  private final CouponRepository couponRepository;
+  private final UserCouponRepository userCouponRepository;
 
   @Transactional
   public Money calculateDiscountAmounts(
       List<OrderLine> orderLines,
-      List<CouponDto> couponDtos,
+      List<UserCouponDto> userCouponDtos,
       MemberGrade grade
   ) {
-    List<Coupon> coupons = couponDtos.stream()
+    List<UserCoupon> userCoupons = userCouponDtos.stream()
         .map(couponDto ->
-            couponRepository.findById(couponDto.id())
+            userCouponRepository.findById(couponDto.id())
                 .orElseThrow(() -> new RuntimeException("Coupon not found")))
         .toList();
 
     Money discountedAmount = orderLines.stream()
-        .map(orderLine -> calculateDiscount(orderLine, coupons))
+        .map(orderLine -> calculateDiscount(orderLine, userCoupons))
         .reduce(new Money(0), (v1, v2) -> v1.add(v2));
-    coupons
-        .forEach(Coupon::useCoupon);
+    userCoupons
+        .forEach(UserCoupon::useCoupon);
 
-    couponRepository.saveAll(coupons);
+    userCouponRepository.saveAll(userCoupons);
 
     return discountedAmount;
   }
 
-  private Money calculateDiscount(List<OrderLine> orderLines, Coupon coupon) {
+  private Money calculateDiscount(List<OrderLine> orderLines, UserCoupon userCoupon) {
     return null;
   }
 
-  private Money calculateDiscount(OrderLine orderLine, List<Coupon> coupons) {
+  private Money calculateDiscount(OrderLine orderLine, List<UserCoupon> userCoupons) {
     Money amount = orderLine.getAmount();
-    return coupons.stream()
+    return userCoupons.stream()
         .map(coupon -> coupon.redeemCoupon(amount))
         .reduce(new Money(0), (v1, v2) -> v1.add(v2));
   }

--- a/src/main/java/com/example/ddd_start/order/domain/service/DiscountCalculationService.java
+++ b/src/main/java/com/example/ddd_start/order/domain/service/DiscountCalculationService.java
@@ -1,33 +1,53 @@
 package com.example.ddd_start.order.domain.service;
 
 import com.example.ddd_start.common.domain.Money;
+import com.example.ddd_start.coupon.application.model.CouponDto;
 import com.example.ddd_start.coupon.domain.Coupon;
+import com.example.ddd_start.coupon.domain.CouponRepository;
 import com.example.ddd_start.member.domain.MemberGrade;
 import com.example.ddd_start.order.domain.OrderLine;
 import java.util.List;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@RequiredArgsConstructor
 public class DiscountCalculationService {
+  private final CouponRepository couponRepository;
 
+  @Transactional
   public Money calculateDiscountAmounts(
       List<OrderLine> orderLines,
-      List<Coupon> coupons,
+      List<CouponDto> couponDtos,
       MemberGrade grade
   ) {
-    Money couponDiscount =
-        coupons.stream()
-            .map(coupon -> calculateDiscount(coupon))
-            .reduce(new Money(0), (v1, v2) -> v1.add(v2));
+    List<Coupon> coupons = couponDtos.stream()
+        .map(couponDto ->
+            couponRepository.findById(couponDto.id())
+                .orElseThrow(() -> new RuntimeException("Coupon not found")))
+        .toList();
 
-    Money membershipDiscount = calculateDiscount(grade);
+    Money discountedAmount = orderLines.stream()
+        .map(orderLine -> calculateDiscount(orderLine, coupons))
+        .reduce(new Money(0), (v1, v2) -> v1.add(v2));
+    coupons
+        .forEach(Coupon::useCoupon);
 
-    return couponDiscount.add(membershipDiscount);
+    couponRepository.saveAll(coupons);
+
+    return discountedAmount;
   }
 
-  private Money calculateDiscount(Coupon coupon) {
-    //...
+  private Money calculateDiscount(List<OrderLine> orderLines, Coupon coupon) {
     return null;
+  }
+
+  private Money calculateDiscount(OrderLine orderLine, List<Coupon> coupons) {
+    Money amount = orderLine.getAmount();
+    return coupons.stream()
+        .map(coupon -> coupon.redeemCoupon(amount))
+        .reduce(new Money(0), (v1, v2) -> v1.add(v2));
   }
 
   private Money calculateDiscount(MemberGrade grade) {

--- a/src/main/java/com/example/ddd_start/order/presentation/CartController.java
+++ b/src/main/java/com/example/ddd_start/order/presentation/CartController.java
@@ -1,0 +1,68 @@
+package com.example.ddd_start.order.presentation;
+
+import com.example.ddd_start.order.application.model.CartDto;
+import com.example.ddd_start.order.application.model.CreateCartCommand;
+import com.example.ddd_start.order.application.service.CartService;
+import com.example.ddd_start.order.application.service.UpdateCartCommand;
+import com.example.ddd_start.order.presentation.model.AddCartRequest;
+import com.example.ddd_start.order.presentation.model.AddCartResponse;
+import com.example.ddd_start.order.presentation.model.UpdateCartRequest;
+import com.example.ddd_start.order.presentation.model.UpdateCartResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Controller
+@RequiredArgsConstructor
+public class CartController {
+
+  private final CartService cartService;
+
+  @GetMapping("/carts")
+  public ResponseEntity<List<CartDto>> printAllCarts(@RequestParam Long memberId) {
+    List<CartDto> cartDtos = cartService.printAllCarts(memberId);
+    return ResponseEntity
+        .ok().body(cartDtos);
+  }
+
+  @PostMapping("/carts")
+  public ResponseEntity addCart(@RequestBody AddCartRequest req) {
+    Long save = cartService.save(
+        new CreateCartCommand(req.memberId(), req.productId(), req.quantity()));
+
+    return ResponseEntity
+        .ok(new AddCartResponse(save, "장바구니에 정상적으로 추가되었습니다."));
+  }
+
+  @PutMapping("/carts")
+  public ResponseEntity updateCart(@RequestBody UpdateCartRequest req) {
+    CartDto update = cartService.update(
+        new UpdateCartCommand(req.cartId(), req.quantity())
+    );
+
+    return ResponseEntity
+        .ok().body(new UpdateCartResponse(update, "장바구니 상품이 정상적으로 변경되었습니다."));
+  }
+
+  @DeleteMapping("/carts")
+  public ResponseEntity deleteCart(@RequestParam Long cartId) {
+    cartService.delete(cartId);
+
+    return ResponseEntity.ok("정상적으로 삭제되었습니다.");
+  }
+
+  @DeleteMapping("/carts-all")
+  public ResponseEntity deleteAllCarts(@RequestParam Long memberId) {
+    cartService.deleteAll(memberId);
+
+    return ResponseEntity.ok("정상적으로 삭제되었습니다.");
+  }
+
+}

--- a/src/main/java/com/example/ddd_start/order/presentation/CartController.java
+++ b/src/main/java/com/example/ddd_start/order/presentation/CartController.java
@@ -18,8 +18,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
-@Controller
+@RestController
 @RequiredArgsConstructor
 public class CartController {
 

--- a/src/main/java/com/example/ddd_start/order/presentation/model/AddCartRequest.java
+++ b/src/main/java/com/example/ddd_start/order/presentation/model/AddCartRequest.java
@@ -1,0 +1,5 @@
+package com.example.ddd_start.order.presentation.model;
+
+public record AddCartRequest(Long memberId, Long productId, Integer quantity) {
+
+}

--- a/src/main/java/com/example/ddd_start/order/presentation/model/AddCartResponse.java
+++ b/src/main/java/com/example/ddd_start/order/presentation/model/AddCartResponse.java
@@ -1,0 +1,5 @@
+package com.example.ddd_start.order.presentation.model;
+
+public record AddCartResponse(Long cartId, String message) {
+
+}

--- a/src/main/java/com/example/ddd_start/order/presentation/model/PlaceOrderRequest.java
+++ b/src/main/java/com/example/ddd_start/order/presentation/model/PlaceOrderRequest.java
@@ -1,7 +1,6 @@
 package com.example.ddd_start.order.presentation.model;
 
-import com.example.ddd_start.coupon.application.model.CouponDto;
-import com.example.ddd_start.coupon.domain.Coupon;
+import com.example.ddd_start.coupon.application.model.UserCouponDto;
 import com.example.ddd_start.order.domain.dto.OrderLineDto;
 import com.example.ddd_start.order.domain.value.Orderer;
 import com.example.ddd_start.order.domain.value.ShippingInfo;
@@ -10,6 +9,6 @@ import java.util.List;
 public record PlaceOrderRequest(List<OrderLineDto> orderLines,
                                 ShippingInfo shippingInfo,
                                 Orderer orderer,
-                                List<CouponDto> coupons) {
+                                List<UserCouponDto> coupons) {
 
 }

--- a/src/main/java/com/example/ddd_start/order/presentation/model/PlaceOrderRequest.java
+++ b/src/main/java/com/example/ddd_start/order/presentation/model/PlaceOrderRequest.java
@@ -1,18 +1,15 @@
 package com.example.ddd_start.order.presentation.model;
 
-import com.example.ddd_start.order.domain.OrderLine;
+import com.example.ddd_start.coupon.application.model.CouponDto;
+import com.example.ddd_start.coupon.domain.Coupon;
+import com.example.ddd_start.order.domain.dto.OrderLineDto;
 import com.example.ddd_start.order.domain.value.Orderer;
 import com.example.ddd_start.order.domain.value.ShippingInfo;
 import java.util.List;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 
-@Getter
-@RequiredArgsConstructor
-public class PlaceOrderRequest {
-
-  private final List<OrderLine> orderLines;
-  private final ShippingInfo shippingInfo;
-  private final Orderer orderer;
+public record PlaceOrderRequest(List<OrderLineDto> orderLines,
+                                ShippingInfo shippingInfo,
+                                Orderer orderer,
+                                List<CouponDto> coupons) {
 
 }

--- a/src/main/java/com/example/ddd_start/order/presentation/model/PlaceOrderResponse.java
+++ b/src/main/java/com/example/ddd_start/order/presentation/model/PlaceOrderResponse.java
@@ -1,0 +1,5 @@
+package com.example.ddd_start.order.presentation.model;
+
+public record PlaceOrderResponse(String message, Long orderId) {
+
+}

--- a/src/main/java/com/example/ddd_start/order/presentation/model/UpdateCartRequest.java
+++ b/src/main/java/com/example/ddd_start/order/presentation/model/UpdateCartRequest.java
@@ -1,0 +1,5 @@
+package com.example.ddd_start.order.presentation.model;
+
+public record UpdateCartRequest(Long cartId, Integer quantity) {
+
+}

--- a/src/main/java/com/example/ddd_start/order/presentation/model/UpdateCartResponse.java
+++ b/src/main/java/com/example/ddd_start/order/presentation/model/UpdateCartResponse.java
@@ -1,0 +1,7 @@
+package com.example.ddd_start.order.presentation.model;
+
+import com.example.ddd_start.order.application.model.CartDto;
+
+public record UpdateCartResponse(CartDto update, String message) {
+
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+server:
+  tomcat:
+    threads:
+      max: 100
 spring:
   config:
     import: optional:file:.env[.properties]


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/1cc3e3d8-40bf-401f-80ab-09282506cf09)

위의 쿠팡과 같이 장바구니가 출력될 수 있게 데이터를 구성해 보았습니다.
장바구니 생명주기
1. 장바구니에 저장할 상품 및 개수 저장
2. 장바구니를 기반으로 주문
3. 주문 생성 완료 시, 장바구니 삭제
 3.1 중간에 필요 없으면 해당 장바구니 삭제 가능